### PR TITLE
Allow events without received_timestamp

### DIFF
--- a/veggie/webapp/dashboard/pages/status.py
+++ b/veggie/webapp/dashboard/pages/status.py
@@ -221,6 +221,8 @@ def get_table_rows() -> list[Any]:
                         datetime.datetime.now(tz=datetime.timezone.utc)
                         - datetime.datetime.fromtimestamp(event["received_timestamp"], tz=datetime.timezone.utc)
                     )
+                    if event.get("received_timestamp")
+                    else "N/A"
                 ),
             ]
         )


### PR DESCRIPTION
Some of the events returned from `/api/events` don't have a `received_timestamp`

E.g.

```
{"args":"()","clock":692,"eta":null,"exchange":"","expires":null,"hostname":"gen7@123456","kwargs":"{}","local_received":1740034800.0201771,"name":"app.tasks.test_task","parent_id":null,"pid":7,"queue":"celery","retries":0,"root_id":"86a12db2-42ac-4213-bc13-5cd72f7341d1","routing_key":"celery","sent_timestamp":1740034800.0052238,"type":"task-sent","utcoffset":0,"uuid":"86a12db2-42ac-4213-bc13-5cd72f7341d1"}
```

I'm not certain why this is, but other parts of the code in `status.py` check whether `received_timestamp` exists or not (line 31) so it seems like it is maybe normal?

This PR checks adds this check to `get_table_rows` as well